### PR TITLE
Fixed typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ class Person {
     [ProtoMember(1)]
     public int Id {get;set;}
     [ProtoMember(2)]
-    public string Name {get;set:}
+    public string Name {get;set;}
     [ProtoMember(3)]
     public Address Address {get;set;}
 }


### PR DESCRIPTION
The readme had a colon instead of a semicolon in the example code.